### PR TITLE
Browser module check

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -12,7 +12,7 @@ var hawk = {};
 
 // Export if used as a module
 
-if (module && module.exports) {
+if (typeof module !== "undefined" && module.exports) {
     module.exports = hawk;
 }
 


### PR DESCRIPTION
Checking for module existence produced "Uncaught ReferenceError: module is not defined". Checking if the type of module is not "undefined" fixes this problem.
