### PR TITLE
Considerations for CORS requests on the browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Current version: **0.12.0**
   - [Protocol Example](#protocol-example)
     - [Payload Validation](#payload-validation)
     - [Response Payload Validation](#response-payload-validation)
-  - [Browser Support](#browser-support)
+  - [Browser Support and Considerations](#browser-support-and-considerations)
 <p></p>
 - [**Single URI Authorization**](#single-uri-authorization)
   - [Usage Example](#bewit-usage-example)
@@ -343,9 +343,12 @@ Server-Authorization: Hawk mac="XIJRsMl/4oL+nn+vKoeVZPdCHXB4yJkNnBbTbHFZUYE=", h
 ```
 
 
-## Browser Support
+## Browser Support and Considerations
 
 An experimental browser script is provided for including using a `<script>` tag in [lib/browser.js](/lib/browser.js).
+
+**Hawk** relies on the _Server-Authorization_ and _WWW-Authenticate_ headers in its response to communicate with the client. Therefore, in case of CORS requests, it is important to consider sending _Access-Control-Expose-Headers_ with the value _"WWW-Authenticate, Server-Authorization"_ on each response from your server. As explained in the [specifications](http://www.w3.org/TR/cors/#access-control-expose-headers-response-header), it will indicate that these headers can safely be accessed by the client (using getResponseHeader() on the XmlHttpRequest object). Otherwise you will be met with a ["simple response header"](http://www.w3.org/TR/cors/#simple-response-header) which excludes these fields and would prevent the Hawk client from authenticating the requests.
+You can read more about the why and how in this [article](http://www.html5rocks.com/en/tutorials/cors/#toc-adding-cors-support-to-the-server)
 
 
 # Single URI Authorization


### PR DESCRIPTION
Explained why it may be necessary to use Access-Control-Expose-Headers when making CORS requests using Hawk.
