### PR TITLE
support for ie < 9

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -169,7 +169,7 @@ hawk.client = {
                     return false;
                 }
 
-                hawk.utils.setNtpOffset(attributes.ts - Math.floor(Date.now() / 1000));     // Keep offset at 1 second precision
+                hawk.utils.setNtpOffset(attributes.ts - Math.floor((new Date()).getTime() / 1000));     // Keep offset at 1 second precision
             }
         }
 
@@ -279,7 +279,7 @@ hawk.client = {
         }
 
         if (updateClock !== false) {
-            hawk.utils.setNtpOffset(message.ts - Math.floor(Date.now() / 1000));    // Keep offset at 1 second precision
+            hawk.utils.setNtpOffset(message.ts - Math.floor((new Date()).getTime() / 1000));    // Keep offset at 1 second precision
         }
 
         return true;
@@ -383,7 +383,7 @@ hawk.utils = {
 
     now: function () {
 
-        return Date.now() + hawk.utils.getNtpOffset();
+        return (new Date()).getTime() + hawk.utils.getNtpOffset();
     },
 
     escapeHeaderAttribute: function (attribute) {
@@ -397,7 +397,7 @@ hawk.utils = {
             return '';
         }
 
-        return header.split(';')[0].trim().toLowerCase();
+        return header.split(';')[0].replace(/^\s+|\s+$/g, '').toLowerCase();
     },
 
     parseAuthorizationHeader: function (header, keys) {


### PR DESCRIPTION
In order to support ie8 we replaced instances of:

``` javascript
Date.now
```

with

``` javascript
(new Date()).getTime()
```

(see http://kangax.github.io/es5-compat-table/#Date.now)

and

``` javascript
string.trim()
```

with

``` javascript
string.replace(/^\s+|\s+$/g, '')
```

(see http://kangax.github.io/es5-compat-table/#String.prototype.trim)
