### PR TITLE
Add "browser" field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "engines": {
     "node": ">=0.8.0"
   },
+  "browser": "./lib/browser.js",
   "dependencies": {
     "hoek": "1.x.x",
     "boom": "2.x.x",


### PR DESCRIPTION
This makes `require('hawk')` return the browser-compatible client
in bundles created by build tools such as browserify.
