### PR TITLE
client.authenticate in browser with browserify

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -154,7 +154,7 @@ hawk.client = {
 
         options = options || {};
 
-        var getResponseHeader = request.getResponseHeader.bind(request) || request.getHeader.bind(request);
+        var getResponseHeader = (request.getResponseHeader || request.getHeader).bind(request);
 
         if (getResponseHeader('www-authenticate')) {
 


### PR DESCRIPTION
I encountered an error with `client.authenticate`. I tried to use the function in the browser inside a browserify bundle. The error is thrown in browser.js:157:
`Uncaught TypeError: Object [object Object] has no method 'getResponseHeader'`.  `[object Object]` referes to the request object.
I figured that's because hawk assumes `request` to be the native xhr object. When using browserify, a node like request object will be passed to the function. The problem is that the node equivalent function to `getResponseHeader` is called `getHeader`. I fixed that by checking which function is available.
