### PR TITLE
Fix time calculation. Stop clearing offset when setting storage.

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -66,7 +66,7 @@ hawk.client = {
 
         // Application time
 
-        var timestamp = options.timestamp || Math.floor((hawk.utils.now() + (options.localtimeOffsetMsec || 0)) / 1000)
+        var timestamp = options.timestamp || hawk.utils.now(options.localtimeOffsetMsec);
 
         // Validate credentials
 
@@ -235,7 +235,7 @@ hawk.client = {
 
         // Application time
 
-        var timestamp = options.timestamp || Math.floor((hawk.utils.now() + (options.localtimeOffsetMsec || 0)) / 1000)
+        var timestamp = options.timestamp || hawk.utils.now(options.localtimeOffsetMsec);
 
         // Validate credentials
 
@@ -365,8 +365,8 @@ hawk.utils = {
 
     setStorage: function (storage) {
 
-        var ntpOffset = hawk.utils.getNtpOffset() || 0;
         hawk.utils.storage = storage;
+        var ntpOffset = hawk.utils.getNtpOffset() || 0;
         hawk.utils.setNtpOffset(ntpOffset);
     },
 
@@ -386,9 +386,9 @@ hawk.utils = {
         return parseInt(hawk.utils.storage.getItem('hawk_ntp_offset') || '0', 10);
     },
 
-    now: function () {
+    now: function (localtimeOffsetMsec) {
 
-        return (new Date()).getTime() + hawk.utils.getNtpOffset();
+        return Math.floor(((new Date()).getTime() + (localtimeOffsetMsec || 0)) / 1000) + hawk.utils.getNtpOffset();
     },
 
     escapeHeaderAttribute: function (attribute) {


### PR DESCRIPTION
Hawk was trying to access the local offset from `localStorage` before any storage was set and therefore replaced the previous (correct) value with 0 which makes the next request fail.

Also, the local offset was added to the timestamp in milliseconds although it's in seconds resulting in failing requests even if the offset value was technically correct. I moved all the offset calculations to `hawk.utils.now` so that the division can be done at the right time.
