### PR TITLE
using correct undefined check for global module variable

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -549,7 +549,7 @@ hawk.crypto.internals = CryptoJS;
 
 // Export if used as a module
 
-if (module && module.exports) {
+if (typeof module !== 'undefined' && module.exports) {
     module.exports = hawk;
 }
 


### PR DESCRIPTION
Without this change, browsers (such as chrome) raise a ReferenceError on this line.

```
Uncaught ReferenceError: module is not defined browser.js:552
(anonymous function)
```

An alternative fix would be

```
if (window.module && module.exports) {
    module.exports = hawk;
}
```
