### PR TITLE
Fix 'undefined module' error in lib/browser.js

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -549,7 +549,7 @@ hawk.crypto.internals = CryptoJS;
 
 // Export if used as a module
 
-if (module && module.exports) {
+if (('undefined' !== typeof(module)) && module.exports) {
     module.exports = hawk;
 }
 


### PR DESCRIPTION
Browsers complain when lib/browser.js is included, because `module` is undefined. Add type checking to resolve this.
