### PR TITLE
simple nonce checking function

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -83,13 +83,35 @@ var internals = {};
  */
 
 exports.authenticate = function (req, credentialsFunc, options, callback) {
+    function nonceCheck(nonce, ts, nonceCallback) {
+      if (typeof this.nonceCache == "undefined") {
+        this.nonceCache = {};
+      }
+      // let's clear all nonces that are in our nonce-store for longer than the timestmap they would be allowed for anway:
+      for (var cachedNonce in this.nonceCache) {
+        var cachedTs = this.nonceCache[cachedNonce];
+        if (Math.abs((cachedTs * 1000) - Utils.now(options.localtimeOffsetMsec)) > (options.timestampSkewSec * 1000)) {
+          delete this.nonceCache[cachedNonce];
+        }
+      }
+      if (nonce in this.nonceCache) {
+        // We have already seen this nonce! Dangerous!
+        return nonceCallback("Error: replay of a nonce, which has been seen within the last timestamp-era");
+      }
+      else {
+        // we haven't seen this one. let's store it and report back that everything is OK.
+        // (timestamps are with milliseconds, see sntp.js, https://github.com/hueniverse/sntp/blob/b8e54ef05fb48ee2d32c287c43aca867ff0969b7/lib/index.js#L397)
+        this.nonceCache[nonce] = ts;
+        return nonceCallback();
+      }
+    }
 
     callback = Hoek.nextTick(callback);
     
     // Default options
 
-    options.nonceFunc = options.nonceFunc || function (nonce, ts, nonceCallback) { return nonceCallback(); };   // No validation
-    options.timestampSkewSec = options.timestampSkewSec || 60;                                                  // 60 seconds
+    options.nonceFunc = options.nonceFunc || nonceCheck;             // No validation
+    options.timestampSkewSec = options.timestampSkewSec || 60;       // 60 seconds
 
     // Application time
 


### PR DESCRIPTION
I have seen quite some implementations on top of this library that do not perform any nonce checking.
Are there any objections to implement this within the library?
This pull request consists of a very primitive attempt :)
With this, I am hoping to prevent some trivial replay attacks and am looking forward to any kind of feedback.
If this here gets positive feedback, I'm inclined to handle timestamp checks prior to the nonce (baiscally move it out of the nonceFunction errback in lines 211-226 and execute it before line 209).

Tests missing, but I'm happy to spend some additional cycles on it, if this whole nonce thing is generally acceptable to you.
