### PR TITLE
Fix URL when using express.Router()

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -72,7 +72,7 @@ exports.parseRequest = function (req, options) {
 
     var request = {
         method: req.method,
-        url: req.url,
+        url: req.originalUrl || req.url,
         host: options.host || host.name,
         port: options.port || host.port,
         authorization: req.headers.authorization,

--- a/test/server.js
+++ b/test/server.js
@@ -73,11 +73,11 @@ describe('Hawk', function () {
                 });
             });
 
-            it('parses a valid authentication header (host override)', function (done) {
-
+            it('parses a valid authentication header (host override and use of an express.Router)', function (done) {
                 var req = {
                     method: 'GET',
-                    url: '/resource/4?filter=a',
+                    originalUrl: '/resource/4?filter=a',
+                    url: '/4?filter=a',
                     headers: {
                         host: 'example1.com:8080',
                         authorization: 'Hawk id="1", ts="1353788437", nonce="k3j4h2", mac="zy79QQ5/EYFmQqutVnYb73gAc/U=", ext="hello"'


### PR DESCRIPTION
Hawk fails when using `express.Router()`
