### PR TITLE
Add bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,32 @@
+{
+  "name": "hawk",
+  "main": "lib/browser.js",
+  "license": "./LICENSE",
+  "ignore": [
+    "example",
+    "images",
+    "!lib",
+    "lib/*",
+    "!lib/browser.js",
+    "test",
+    ".gitignore",
+    ".travis.yml",
+    "Makefile",
+    "component.json",
+    "index.js",
+    "package.json"
+  ],
+  "keywords": [
+    "http",
+    "authentication",
+    "scheme",
+    "hawk"
+  ],
+  "authors": [
+    "Eran Hammer <eran@hammer.io>"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/hueniverse/hawk.git"
+  }
+}

--- a/bower.json
+++ b/bower.json
@@ -3,18 +3,10 @@
   "main": "lib/browser.js",
   "license": "./LICENSE",
   "ignore": [
-    "example",
-    "images",
     "!lib",
     "lib/*",
     "!lib/browser.js",
-    "test",
-    ".gitignore",
-    ".travis.yml",
-    "Makefile",
-    "component.json",
-    "index.js",
-    "package.json"
+    "index.js"
   ],
   "keywords": [
     "http",


### PR DESCRIPTION
This PR allows the use of this repo as a bower dependency. It's an improvement over simply using the GitHub repository as build plugins like [main-bower-files](/ck86/main-bower-files) require the `main` property in the bower.json.