### PR TITLE
Fix missing options.host TypeError

### DIFF
--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -67,7 +67,7 @@ exports.generateNormalizedString = function (type, options) {
                      options.nonce + '\n' +
                      (options.method || '').toUpperCase() + '\n' +
                      resource + '\n' +
-                     options.host.toLowerCase() + '\n' +
+                     (options.host || '').toLowerCase() + '\n' +
                      options.port + '\n' +
                      (options.hash || '') + '\n';
 


### PR DESCRIPTION
Sometimes `generateNormalizedString` doesn't get given a valid `options.host` which causes a `TypeError: Cannot call method 'toLowerCase' of undefined`