### PR TITLE
Fixed missing options.host TypeError

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,28 @@
+{
+    "rules": {
+        "no-console": 0,
+        "no-unused-vars": 0,
+        "indent": [
+            2,
+            4
+        ],
+        "quotes": [
+            2,
+            "single"
+        ],
+        "linebreak-style": [
+            2,
+            "unix"
+        ],
+        "semi": [
+            2,
+            "always"
+        ]
+    },
+    "env": {
+        "es6": true,
+        "node": true,
+        "browser": true
+    },
+    "extends": "eslint:recommended"
+}

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -67,7 +67,7 @@ exports.generateNormalizedString = function (type, options) {
                      options.nonce + '\n' +
                      (options.method || '').toUpperCase() + '\n' +
                      resource + '\n' +
-                     options.host.toLowerCase() + '\n' +
+                     (options.host || '').toLowerCase() + '\n' +
                      options.port + '\n' +
                      (options.hash || '') + '\n';
 

--- a/test/crypto.js
+++ b/test/crypto.js
@@ -66,5 +66,20 @@ describe('Crypto', function () {
 
             done();
         });
+
+        it('should return a valid normalized string handling undefined host', function (done) {
+
+            expect(Hawk.crypto.generateNormalizedString('header', {
+                ts: 1357747017,
+                nonce: 'k3k4j5',
+                method: 'GET',
+                resource: '/resource/something',
+                port: 8080,
+                hash: 'U4MKKSmiVxk37JCCrAVIjV/OhB3y+NdwoCr6RShbVkE=',
+                ext: 'this is some app data'
+            })).to.equal('hawk.1.header\n1357747017\nk3k4j5\nGET\n/resource/something\n\n8080\nU4MKKSmiVxk37JCCrAVIjV/OhB3y+NdwoCr6RShbVkE=\nthis is some app data\n');
+
+            done();
+        });
     });
 });


### PR DESCRIPTION
Handle when `generateNormalizedString` gets an undefined `options.host` which causes a `TypeError: Cannot call method 'toLowerCase' of undefined`

Added eslint configuration file.
Added crypto test for undefined host.