### PR TITLE
Update the README Travis badge to use the new preferred URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Current version: **4.x**
 
 Note: 4.x, 3.x, and 2.x are the same exact protocol as 1.1. The version increments reflect changes in the node API.
 
-[![Build Status](https://secure.travis-ci.org/hueniverse/hawk.png)](http://travis-ci.org/hueniverse/hawk)
+[![Build Status](https://travis-ci.org/hueniverse/hawk.svg?branch=master)](https://travis-ci.org/hueniverse/hawk)
 
 # Table of Content
 


### PR DESCRIPTION
Broken out of #155.