### PR TITLE
fix alternative response object format

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -22,9 +22,10 @@ const internals = {};
                         const request = {
                             method: 'GET',
                             url: '/resource/4?a=1&b=2',
-                            host: 'example.com',
-                            port: 8080,
-                            authorization: 'Hawk id="dh37fgj492je", ts="1353832234", nonce="j4h3g2", ext="some-app-ext-data", mac="6R4rV5iE+NPoym+WwjeHzjAGXUtLNIxmo1vpMofpLAE="'
+                            headers: {
+                               host: 'example.com:8000',
+                               authorization: 'Hawk id="dh37fgj492je", ts="1353832234", nonce="j4h3g2", ext="some-app-ext-data", mac="6R4rV5iE+NPoym+WwjeHzjAGXUtLNIxmo1vpMofpLAE="'
+                            }
                         };
 
    credentialsFunc:     required function to lookup the set of Hawk credentials based on the provided credentials id.


### PR DESCRIPTION
This updated format for the alternative response object provided to server.authenticate, when not using node's HTTP request object, works, whereas the old format did not.