### PR TITLE
Add images/* to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -16,3 +16,4 @@ config.json
 coverage.*
 lib-cov
 complexity.md
+images/*


### PR DESCRIPTION
Project logo isn't needed to be included into the package.
Images referenced only in the readme and so it's visible if README.md
compiled to a html page, which is done usually on github.