### PR TITLE
Fix minor DoS attack on long headers or uris.

### DIFF
--- a/dist/client.js
+++ b/dist/client.js
@@ -4,7 +4,10 @@
 
 ;
 
-function _typeof(obj) { return obj && typeof Symbol !== "undefined" && obj.constructor === Symbol ? "symbol" : typeof obj; }
+var _typeof = function (obj) {
+
+    return obj && typeof Symbol !== 'undefined' && obj.constructor === Symbol ? 'symbol' : typeof obj;
+};
 
 var Url = require('url');
 var Hoek = require('hoek');

--- a/lib/server.js
+++ b/lib/server.js
@@ -308,6 +308,11 @@ exports.header = function (credentials, artifacts, options) {
  * 'hostHeaderName', 'localtimeOffsetMsec', 'host', 'port'
  */
 
+
+//                       1     2             3           4
+internals.bewitRegex = /^(\/.*)([\?&])bewit\=([^&$]*)(?:&(.+))?$/;
+
+
 exports.authenticateBewit = function (req, credentialsFunc, options, callback) {
 
     callback = Hoek.nextTick(callback);
@@ -325,8 +330,11 @@ exports.authenticateBewit = function (req, credentialsFunc, options, callback) {
 
     // Extract bewit
 
-    //                                 1     2             3           4
-    var resource = request.url.match(/^(\/.*)([\?&])bewit\=([^&$]*)(?:&(.+))?$/);
+    if (request.url.length > Utils.limits.maxMatchLength) {
+        return callback(Boom.badRequest('Resource path exceeds max length'));
+    }
+
+    var resource = request.url.match(internals.bewitRegex);
     if (!resource) {
         return callback(Boom.unauthorized(null, 'Hawk'));
     }

--- a/test/server.js
+++ b/test/server.js
@@ -970,6 +970,33 @@ describe('Server', function () {
         });
     });
 
+    describe('authenticateBewit()', function () {
+
+        it('errors on uri too long', function (done) {
+
+            var long = '/';
+            for (var i = 0; i < 5000; ++i) {
+                long += 'x';
+            }
+
+            var req = {
+                method: 'GET',
+                url: long,
+                host: 'example.com',
+                port: 8080,
+                authorization: 'Hawk id="1", ts="1353788437", nonce="k3j4h2", mac="zy79QQ5/EYFmQqutVnYb73gAc/U=", ext="hello"'
+            };
+
+            Hawk.server.authenticateBewit(req, credentialsFunc, {}, function (err, credentials, bewit) {
+
+                expect(err).to.exist();
+                expect(err.output.statusCode).to.equal(400);
+                expect(err.message).to.equal('Resource path exceeds max length');
+                done();
+            });
+        });
+    });
+
     describe('authenticateMessage()', function () {
 
         it('errors on invalid authorization (ts)', function (done) {

--- a/test/utils.js
+++ b/test/utils.js
@@ -93,6 +93,34 @@ describe('Utils', function () {
             expect(host.name).to.equal('[123:123:123]');
             done();
         });
+
+        it('errors on header too long', function (done) {
+
+            var long = '';
+            for (var i = 0; i < 5000; ++i) {
+                long += 'x';
+            }
+
+            expect(Hawk.utils.parseHost({ headers: { host: long } })).to.be.null();
+            done();
+        });
+    });
+
+    describe('parseAuthorizationHeader()', function () {
+
+        it('errors on header too long', function (done) {
+
+            var long = 'Scheme a="';
+            for (var i = 0; i < 5000; ++i) {
+                long += 'x';
+            }
+            long += '"';
+
+            var err = Hawk.utils.parseAuthorizationHeader(long, ['a']);
+            expect(err).to.be.instanceof(Error);
+            expect(err.message).to.equal('Header length too long');
+            done();
+        });
     });
 
     describe('version()', function () {


### PR DESCRIPTION
Replaces #170

This PR, which is really just this [commit](https://github.com/hueniverse/hawk/commit/ccebde4b24d06014ac573888a21813b29a4a16c7) fixes the DoS attack that was merged into 4.x code, but applies it to the 3.x code. 

This seemed important specifically because [request](https://npmjs.org/request) relies on hawk@3.x and have [said they're not ready to drop node < 4 support](https://github.com/request/request/issues/2020) (which would come via hawk@4).

So this patch will offer a 3.1.x version that has the vuln fixed, which should allow request to update their dependencies.

This particular [patch](https://github.com/Snyk/vulndb/tree/3997877197b75c7e41c9eac1825040cf2246597b/data/npm/hawk/20160119) was generated for [Snyk](https://snyk.io) users, but we'd rather see users be able to do updates over patches in their remediation.

I hope this patch will be considered and merge (for release to 3.1.3). Thanks!