### PR TITLE
Remove HTML tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,8 @@ Note: 4.x, 3.x, and 2.x are the same exact protocol as 1.1. The version incremen
     - [Payload Validation](#payload-validation)
     - [Response Payload Validation](#response-payload-validation)
   - [Browser Support and Considerations](#browser-support-and-considerations)
-<p></p>
 - [**Single URI Authorization**](#single-uri-authorization)
   - [Usage Example](#bewit-usage-example)
-<p></p>
 - [**Security Considerations**](#security-considerations)
   - [MAC Keys Transmission](#mac-keys-transmission)
   - [Confidentiality of Requests](#confidentiality-of-requests)
@@ -33,9 +31,7 @@ Note: 4.x, 3.x, and 2.x are the same exact protocol as 1.1. The version incremen
   - [Client Clock Poisoning](#client-clock-poisoning)
   - [Bewit Limitations](#bewit-limitations)
   - [Host Header Forgery](#host-header-forgery)
-<p></p>
 - [**Frequently Asked Questions**](#frequently-asked-questions)
-<p></p>
 - [**Implementations**](#implementations)
 - [**Acknowledgements**](#acknowledgements)
 


### PR DESCRIPTION
Currently README is broken on npm because of these HTML tags.

<img width="765" alt="screen shot 2016-03-09 at 22 32 57" src="https://cloud.githubusercontent.com/assets/371149/13651281/ef6911cc-e646-11e5-97ae-d74156c89aa2.png">
