### PR TITLE
Pass request to credentials function 

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -403,47 +403,92 @@ exports.authenticateBewit = function (req, credentialsFunc, options, callback) {
     }
 
     // Fetch Hawk credentials
+    if (options.passReqToCallback) {
+        const reqToCallback = req;
 
-    credentialsFunc(bewit.id, (err, credentials) => {
+        credentialsFunc(reqToCallback, bewit.id, (err, credentials) => {
 
-        if (err) {
-            return callback(err, credentials || null, bewit.ext);
-        }
+            if (err) {
+                return callback(err, credentials || null, bewit.ext);
+            }
 
-        if (!credentials) {
-            return callback(Utils.unauthorized('Unknown credentials'), null, bewit);
-        }
+            if (!credentials) {
+                return callback(Utils.unauthorized('Unknown credentials'), null, bewit);
+            }
 
-        if (!credentials.key ||
-            !credentials.algorithm) {
+            if (!credentials.key ||
+                !credentials.algorithm) {
 
-            return callback(Boom.internal('Invalid credentials'), credentials, bewit);
-        }
+                return callback(Boom.internal('Invalid credentials'), credentials, bewit);
+            }
 
-        if (Crypto.algorithms.indexOf(credentials.algorithm) === -1) {
-            return callback(Boom.internal('Unknown algorithm'), credentials, bewit);
-        }
+            if (Crypto.algorithms.indexOf(credentials.algorithm) === -1) {
+                return callback(Boom.internal('Unknown algorithm'), credentials, bewit);
+            }
 
-        // Calculate MAC
+            // Calculate MAC
 
-        const mac = Crypto.calculateMac('bewit', credentials, {
-            ts: bewit.exp,
-            nonce: '',
-            method: 'GET',
-            resource: url,
-            host: request.host,
-            port: request.port,
-            ext: bewit.ext
+            const mac = Crypto.calculateMac('bewit', credentials, {
+                ts: bewit.exp,
+                nonce: '',
+                method: 'GET',
+                resource: url,
+                host: request.host,
+                port: request.port,
+                ext: bewit.ext
+            });
+
+            if (!Cryptiles.fixedTimeComparison(mac, bewit.mac)) {
+                return callback(Utils.unauthorized('Bad mac'), credentials, bewit);
+            }
+
+            // Successful authentication
+
+            return callback(null, credentials, bewit);
         });
+    }
+    else {
+        credentialsFunc(bewit.id, (err, credentials) => {
 
-        if (!Cryptiles.fixedTimeComparison(mac, bewit.mac)) {
-            return callback(Utils.unauthorized('Bad mac'), credentials, bewit);
-        }
+            if (err) {
+                return callback(err, credentials || null, bewit.ext);
+            }
 
-        // Successful authentication
+            if (!credentials) {
+                return callback(Utils.unauthorized('Unknown credentials'), null, bewit);
+            }
 
-        return callback(null, credentials, bewit);
-    });
+            if (!credentials.key ||
+                !credentials.algorithm) {
+
+                return callback(Boom.internal('Invalid credentials'), credentials, bewit);
+            }
+
+            if (Crypto.algorithms.indexOf(credentials.algorithm) === -1) {
+                return callback(Boom.internal('Unknown algorithm'), credentials, bewit);
+            }
+
+            // Calculate MAC
+
+            const mac = Crypto.calculateMac('bewit', credentials, {
+                ts: bewit.exp,
+                nonce: '',
+                method: 'GET',
+                resource: url,
+                host: request.host,
+                port: request.port,
+                ext: bewit.ext
+            });
+
+            if (!Cryptiles.fixedTimeComparison(mac, bewit.mac)) {
+                return callback(Utils.unauthorized('Bad mac'), credentials, bewit);
+            }
+
+            // Successful authentication
+
+            return callback(null, credentials, bewit);
+        });
+    }
 };
 
 


### PR DESCRIPTION
Pass request to credentials function to allow the usage of Passportjs `passReqToCallback: true`
 option in passport-hawk if requested.