### PR TITLE
Added basePath option...

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -79,6 +79,9 @@ const internals = {};
 
         host:                  optional host name override. Only used when passed a node request object.
         port:                  optional port override. Only used when passed a node request object.
+        basePath:              optional path to prefix the request url with. Only used when passed a node request object. Useful
+                               in cases where the node request url has been modified upstream (by the expressjs middleware
+                               library as an example).
     }
 
     callback: function (err, credentials, artifacts) { }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -86,7 +86,7 @@ exports.parseRequest = function (req, options) {
 
     const request = {
         method: req.method,
-        url: req.url,
+        url: (options.basePath || '') + req.url,
         host: options.host || host.name,
         port: options.port || host.port,
         authorization: req.headers.authorization,

--- a/test/server.js
+++ b/test/server.js
@@ -111,6 +111,25 @@ describe('Server', () => {
             });
         });
 
+        it('parses a valid authentication header (url basePath override)', (done) => {
+
+            const req = {
+                method: 'GET',
+                url: '/4?filter=a',
+                headers: {
+                    host: 'example.com:8080',
+                    authorization: 'Hawk id="1", ts="1353788437", nonce="k3j4h2", mac="zy79QQ5/EYFmQqutVnYb73gAc/U=", ext="hello"'
+                }
+            };
+
+            Hawk.server.authenticate(req, credentialsFunc, { localtimeOffsetMsec: 1353788437000 - Hawk.utils.now(), basePath: '/resource' }, (err, credentials, artifacts) => {
+
+                expect(err).to.not.exist();
+                expect(credentials.user).to.equal('steve');
+                done();
+            });
+        });
+
         it('parses a valid authentication header (POST with payload)', (done) => {
 
             const req = {


### PR DESCRIPTION
 to allow the url to be prefixed when authenticating a node request. This changes provides a solution to the issue raised here https://github.com/hueniverse/hawk/issues/201