### PR TITLE
Browser authentication function accepts callback as fifth argument

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -226,9 +226,33 @@ hawk.client = {
         }
     */
 
-    authenticate: function (request, credentials, artifacts, options) {
+    authenticate: function (request, credentials, artifacts, options, callback) {
 
         options = options || {};
+
+        let wwwAttributes = null;
+        let serverAuthAttributes = null;
+
+        const finalize = function (authenticated) {
+
+            let err = null;
+            let headers = null;
+            if (authenticated) {
+                headers = {
+                    'www-authenticate': wwwAttributes,
+                    'server-authorization': serverAuthAttributes
+                };
+            }
+            else {
+                err = new Error('Failed authentication');
+            }
+
+            if (typeof callback === 'function') {
+                callback(err, headers);
+            }
+
+            return authenticated;
+        };
 
         const getHeader = function (name) {
 
@@ -248,15 +272,15 @@ hawk.client = {
 
             // Parse HTTP WWW-Authenticate header
 
-            const wwwAttributes = hawk.utils.parseAuthorizationHeader(wwwAuthenticate, ['ts', 'tsm', 'error']);
+            wwwAttributes = hawk.utils.parseAuthorizationHeader(wwwAuthenticate, ['ts', 'tsm', 'error']);
             if (!wwwAttributes) {
-                return false;
+                return finalize(false);
             }
 
             if (wwwAttributes.ts) {
                 const tsm = hawk.crypto.calculateTsMac(wwwAttributes.ts, credentials);
                 if (tsm !== wwwAttributes.tsm) {
-                    return false;
+                    return finalize(false);
                 }
 
                 hawk.utils.setNtpSecOffset(wwwAttributes.ts - Math.floor(Date.now() / 1000));      // Keep offset at 1 second precision
@@ -269,12 +293,12 @@ hawk.client = {
         if (!serverAuthorization &&
             !options.required) {
 
-            return true;
+            return finalize(true);
         }
 
-        const attributes = hawk.utils.parseAuthorizationHeader(serverAuthorization, ['mac', 'ext', 'hash']);
-        if (!attributes) {
-            return false;
+        serverAuthAttributes = hawk.utils.parseAuthorizationHeader(serverAuthorization, ['mac', 'ext', 'hash']);
+        if (!serverAuthAttributes) {
+            return finalize(false);
         }
 
         const modArtifacts = {
@@ -284,29 +308,29 @@ hawk.client = {
             resource: artifacts.resource,
             host: artifacts.host,
             port: artifacts.port,
-            hash: attributes.hash,
-            ext: attributes.ext,
+            hash: serverAuthAttributes.hash,
+            ext: serverAuthAttributes.ext,
             app: artifacts.app,
             dlg: artifacts.dlg
         };
 
         const mac = hawk.crypto.calculateMac('response', credentials, modArtifacts);
-        if (mac !== attributes.mac) {
-            return false;
+        if (mac !== serverAuthAttributes.mac) {
+            return finalize(false);
         }
 
         if (!options.payload &&
             options.payload !== '') {
 
-            return true;
+            return finalize(true);
         }
 
-        if (!attributes.hash) {
-            return false;
+        if (!serverAuthAttributes.hash) {
+            return finalize(false);
         }
 
         const calculatedHash = hawk.crypto.calculatePayloadHash(options.payload, credentials.algorithm, getHeader('content-type'));
-        return (calculatedHash === attributes.hash);
+        return finalize(calculatedHash === serverAuthAttributes.hash);
     },
 
     message: function (host, port, message, options) {


### PR DESCRIPTION
This makes the signature of the browser authentication function a "equivalent" to the [client authenticate function](https://github.com/hueniverse/hawk/blob/v6.0.1/lib/client.js#L149) and allows Oz/lib/client to use it in the browser [as partially discussed here](https://github.com/hueniverse/oz/issues/53#issuecomment-300639336).

I don't know if this is of interest, if so I'll happily write some tests.

Thanks for the bounty of amazing libraries @hueniverse !