### PR TITLE
Replaced `es2015` preset for `env`

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "babel": {
     "presets": [
-      "es2015"
+      "env"
     ]
   },
   "scripts": {


### PR DESCRIPTION
On https://github.com/hueniverse/hawk/pull/216 it was changed for development of the own project, but it was missing this preset when using as dependency. This change should fix it.