### PR TITLE
Bump hoek version from 2.x.x to 4.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "browser": "./lib/browser.js",
   "dependencies": {
-    "hoek": "2.x.x",
+    "hoek": "4.x.x",
     "boom": "2.x.x",
     "cryptiles": "2.x.x",
     "sntp": "1.x.x"


### PR DESCRIPTION
This PR bumps the `hoek` dependency version from `2.x.x` to `4.x.x`.  This fixes a [security vulnerability](https://snyk.io/vuln/npm:hoek:20180212) in `hoek`.  The vulnerability fix was backported into `hoek@4.x.x` in [this PR](https://github.com/hapijs/hoek/pull/231).

NOE: This PR's base fork is the `v3.1.x` branch; as you mentioned in #234, the mainline's dependency range remains secure.

NOTE: The latest version of `hoek` is `5.0.3`.  However, `Hoek.nextTick` was removed in [this commit](https://github.com/hapijs/hoek/commit/5f7e4dea1fec7cb58bf3eaa73ff4fc04bdb8e62d#diff-6d186b954a58d5bb740f73d84fe39073L851), so I have opted to only upgrade to `hoek@4.x.x` to avoid that breaking change.

Thank you for your time.