### PR TITLE
docs(server): Update return value

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -211,7 +211,7 @@ exports.authenticate = async function (req, credentialsFunc, options) {
     artifacts:      from authenticate()
     contentType:    req.headers['content-type']
 
-    Return value: { credentials, artifacts } or throws an error.
+    Return value: void or throws an error.
 */
 
 exports.authenticatePayload = function (payload, credentials, artifacts, contentType) {
@@ -229,7 +229,7 @@ exports.authenticatePayload = function (payload, credentials, artifacts, content
     calculatedHash: the payload hash calculated using Crypto.calculatePayloadHash()
     artifacts:      from authenticate()
 
-    Return value: { artifacts } or throws an error.
+    Return value: void or throws an error.
 */
 
 exports.authenticatePayloadHash = function (calculatedHash, artifacts) {


### PR DESCRIPTION
The described return values for `authenticatePayload()` and `authenticatePayloadHash()` were not correct since they both return `void`.